### PR TITLE
Update Readme to point to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Typescript program to generate encounters for [*13th Age*](http://13thage.com/
 
 ## Usage
 
-The easy way is to visit the online instance at [http://manticore.brehaut.net](http://manticore.brehaut.net).
+The easy way is to visit the online instance at [https://manticore.brehaut.net](https://manticore.brehaut.net).
 	
 If you want to run/develop it locally you will need [Node JS](https://nodejs.org/), [Gulp](http://gulpjs.com), and `make` installed to build this project:
 


### PR DESCRIPTION
Per Issue #51, the HTTP url does not currently work on Chrome / FF. The HTTPS one does however, and so should be the recommended one in the readme